### PR TITLE
Add package.json / yarn.lock to v2-api volumes in dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,8 @@ services:
       dockerfile: ./docker/dev.Dockerfile
     image: "ghcr.io/hyperqube-io/v2-api:local"
     volumes:
+      - ${DEV_V2_API_DIR}/package.json:/package.json
+      - ${DEV_V2_API_DIR}/yarn.lock:/yarn.lock
       - ${DEV_V2_API_DIR}/src:/src
   v2-web:
     image: alpine:latest


### PR DESCRIPTION
So we can do `docker-compose exec hq-v2-api yarn` when we change dependencies in dev
